### PR TITLE
Removing a call with some 'hack'.

### DIFF
--- a/notebooks/week_5/basic_simulation_analysis.ipynb
+++ b/notebooks/week_5/basic_simulation_analysis.ipynb
@@ -130,19 +130,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Hack : cell we need to remove with a better simulation\n",
-    "times = filtered_spikes.report.index.values\n",
-    "filtered_spikes.report.loc[times.max() + 0.15] = [3311, \"hippocampus_neurons\"]\n",
-    "times = filtered_spikes.report.index.values\n",
-    "filtered_spikes.report.loc[times.max() + 0.15] = [602, \"hippocampus_neurons\"]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [


### PR DESCRIPTION
Proposal: To remove the cell with the "hack". Most probable it was added in order to show how things work with bluepysnap. 

This hack was adding two spikes in addition to ~140 spikes. The plots change a bit, but are very similar. 